### PR TITLE
Add allow(unused_mut) to package.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 #![feature(core)]
 #![deny(warnings)]
 #![no_std]
+#![allow(unused_mut)]
 
 extern crate core;
 


### PR DESCRIPTION
Rust doesn't acknowledge variables used as outputs in asm! are mutated as of `rustc 1.3.0-nightly (d33cab1b1 2015-07-22)` 
