### PR TITLE
fix "extern crate core" import

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,9 @@
 #![crate_type="lib"]
 
 #![feature(asm, no_std)]
-#![feature(core)]
 #![deny(warnings)]
 #![no_std]
 #![allow(unused_mut)]
-
-extern crate core;
 
 #[cfg(test)]
 extern crate std;


### PR DESCRIPTION
Build was broken on latest rust nightly because using no_std now automatically injects an "extern crate core".

rust-lang/rfcs#1184
https://github.com/rust-lang/rust/commit/5cccf3cd256420d9f32c265e83036dea1d5f94d8