### PR TITLE
Added linux-aarch64 platform

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,3 +43,7 @@ pub mod platform;
 #[cfg(all(target_os="macos", target_arch="x86_64"))]
 #[path="platform/macos-x86_64/mod.rs"]
 pub mod platform;
+
+#[cfg(all(target_os="linux", target_arch="aarch64"))]
+#[path="platform/linux-aarch64/mod.rs"]
+pub mod platform;

--- a/src/platform/linux-aarch64/mod.rs
+++ b/src/platform/linux-aarch64/mod.rs
@@ -1,0 +1,99 @@
+// Copyright 2014 The syscall.rs Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Veecxon 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except accoebxng to those terms.
+
+//! This library was built for aarch64 Linux.
+
+pub mod nr;
+
+#[inline(always)]
+pub unsafe fn syscall0(n: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall1(n: usize, a1: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall2(n: usize, a1: usize, a2: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall3(n: usize, a1: usize, a2: usize, a3: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall4(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall5(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize, a5: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4),
+                     "{x4}"(a5)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall6(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize, a5: usize, a6: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4),
+                     "{x4}"(a5), "{x6}"(a6)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}
+
+#[inline(always)]
+pub unsafe fn syscall7(n: usize, a1: usize, a2: usize, a3: usize,
+                                a4: usize, a5: usize, a6: usize) -> usize {
+    let ret : usize;
+    asm!("svc 0"   : "={x0}"(ret)
+                   : "{x8}"(n), "{x0}"(a1), "{x1}"(a2), "{x2}"(a3), "{x3}"(a4)
+                     "{x4}"(a5), "{x6}"(a6)
+                   : "memory" "cc"
+                   : "volatile");
+    ret
+}

--- a/src/platform/linux-aarch64/nr.rs
+++ b/src/platform/linux-aarch64/nr.rs
@@ -1,0 +1,386 @@
+// Copyright 2014 The syscall.rs Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! System call numbers for AArch64 Linux.
+
+/*
+
+These system calls are either obsolete on this architecture or the create values are not known
+
+pub const FORK : usize = __NR_fork;
+pub const OPEN : usize = __NR_open;
+pub const CREAT : usize = __NR_creat;
+pub const LINK : usize = __NR_link;
+pub const UNLINK : usize = __NR_unlink;
+pub const TIME : usize = __NR_time;
+pub const MKNOD : usize = __NR_mknod;
+pub const CHMOD : usize = __NR_chmod;
+pub const LCHOWN : usize = __NR_lchown;
+pub const UMOUNT : usize = __NR_umount;
+pub const STIME : usize = __NR_stime;
+pub const ALARM : usize = __NR_alarm;
+pub const PAUSE : usize = __NR_pause;
+pub const UTIME : usize = __NR_utime;
+pub const ACCESS : usize = __NR_access;
+pub const NICE : usize = __NR_nice;
+pub const RENAME : usize = __NR_rename;
+pub const MKDIR : usize = __NR_mkdir;
+pub const RMDIR : usize = __NR_rmdir;
+pub const PIPE : usize = __NR_pipe;
+pub const USTAT : usize = __NR_ustat;
+pub const DUP2 : usize = __NR_dup2;
+pub const GETPGRP : usize = __NR_getpgrp;
+pub const SIGACTION : usize = __NR_sigaction;
+pub const SIGSUSPEND : usize = __NR_sigsuspend;
+pub const SIGPENDING : usize = __NR_sigpending;
+pub const SELECT : usize = __NR_select;
+pub const SYMLINK : usize = __NR_symlink;
+pub const READLINK : usize = __NR_readlink;
+pub const USELIB : usize = __NR_uselib;
+pub const READDIR : usize = __NR_readdir;
+pub const SOCKETCALL : usize = __NR_socketcall;
+pub const STAT : usize = __NR_stat;
+pub const LSTAT : usize = __NR_lstat;
+pub const SYSCALL : usize = __NR_syscall;
+pub const IPC : usize = __NR_ipc;
+pub const SIGRETURN : usize = __NR_sigreturn;
+pub const SIGPROCMASK : usize = __NR_sigprocmask;
+pub const CHOWN : usize = __NR_chown;
+pub const BDFLUSH : usize = __NR_bdflush;
+pub const SYSFS : usize = __NR_sysfs;
+pub const _LLSEEK : usize = __NR__llseek;
+pub const GETDENTS : usize = __NR_getdents;
+pub const _NEWSELECT : usize = __NR__newselect;
+pub const _SYSCTL : usize = __NR__sysctl;
+pub const POLL : usize = __NR_poll;
+pub const VFORK : usize = __NR_vfork;
+pub const UGETRLIMIT : usize = __NR_ugetrlimit;
+pub const MMAP2 : usize = __NR_mmap2;
+pub const TRUNCATE64 : usize = __NR_truncate64;
+pub const FTRUNCATE64 : usize = __NR_ftruncate64;
+pub const STAT64 : usize = __NR_stat64;
+pub const LSTAT64 : usize = __NR_lstat64;
+pub const FSTAT64 : usize = __NR_fstat64;
+pub const LCHOWN32 : usize = __NR_lchown32;
+pub const GETUID32 : usize = __NR_getuid32;
+pub const GETGID32 : usize = __NR_getgid32;
+pub const GETEUID32 : usize = __NR_geteuid32;
+pub const GETEGID32 : usize = __NR_getegid32;
+pub const SETREUID32 : usize = __NR_setreuid32;
+pub const SETREGID32 : usize = __NR_setregid32;
+pub const GETGROUPS32 : usize = __NR_getgroups32;
+pub const SETGROUPS32 : usize = __NR_setgroups32;
+pub const FCHOWN32 : usize = __NR_fchown32;
+pub const SETRESUID32 : usize = __NR_setresuid32;
+pub const GETRESUID32 : usize = __NR_getresuid32;
+pub const SETRESGID32 : usize = __NR_setresgid32;
+pub const GETRESGID32 : usize = __NR_getresgid32;
+pub const CHOWN32 : usize = __NR_chown32;
+pub const SETUID32 : usize = __NR_setuid32;
+pub const SETGID32 : usize = __NR_setgid32;
+pub const SETFSUID32 : usize = __NR_setfsuid32;
+pub const SETFSGID32 : usize = __NR_setfsgid32;
+pub const FCNTL64 : usize = __NR_fcntl64;
+pub const SENDFILE64 : usize = __NR_sendfile64;
+pub const EPOLL_CREATE : usize = __NR_epoll_create;
+pub const EPOLL_WAIT : usize = __NR_epoll_wait;
+pub const STATFS64 : usize = __NR_statfs64;
+pub const FSTATFS64 : usize = __NR_fstatfs64;
+pub const UTIMES : usize = __NR_utimes;
+pub const ARM_FADVISE64_64 : usize = __NR_arm_fadvise64_64;
+pub const PCICONFIG_IOBASE : usize = __NR_pciconfig_iobase;
+pub const PCICONFIG_READ : usize = __NR_pciconfig_read;
+pub const PCICONFIG_WRITE : usize = __NR_pciconfig_write;
+pub const SEND : usize = __NR_send;
+pub const RECV : usize = __NR_recv;
+pub const VSERVER : usize = __NR_vserver;
+pub const INOTIFY_INIT : usize = __NR_inotify_init;
+pub const FUTIMESAT : usize = __NR_futimesat;
+pub const FSTATAT64 : usize = __NR_fstatat64;
+pub const ARM_SYNC_FILE_RANGE : usize = __NR_arm_sync_file_range;
+pub const SYNC_FILE_RANGE2 : usize = __NR_sync_file_range2;
+pub const SIGNALFD : usize = __NR_signalfd;
+pub const EVENTFD : usize = __NR_eventfd;
+*/
+
+pub const RESTART_SYSCALL : usize = 128;
+pub const EXIT : usize = 93;
+pub const READ : usize = 63;
+pub const WRITE : usize = 64;
+pub const CLOSE : usize = 57;
+pub const EXECVE : usize = 221;
+pub const CHDIR : usize = 49;
+
+pub const LSEEK : usize = 62;
+pub const GETPID : usize = 172;
+pub const MOUNT : usize = 40;
+pub const SETUID : usize = 146;
+pub const GETUID : usize = 174;
+pub const PTRACE : usize = 117;
+
+pub const SYNC : usize = 81;
+pub const KILL : usize = 129;
+pub const DUP : usize = 23;
+pub const TIMES : usize = 153;
+
+pub const BRK : usize = 214;
+pub const SETGID : usize = 144;
+pub const GETGID : usize = 176;
+
+pub const GETEUID : usize = 175;
+pub const GETEGID : usize = 177;
+pub const ACCT : usize = 89;
+pub const UMOUNT2 : usize = 39;
+
+pub const IOCTL : usize = 29;
+pub const FCNTL : usize = 25;
+
+pub const SETPGID : usize = 154;
+
+pub const UMASK : usize = 166;
+pub const CHROOT : usize = 51;
+pub const GETPPID : usize = 173;
+pub const SETSID : usize = 157;
+
+pub const SETREUID : usize = 145;
+pub const SETREGID : usize = 143;
+pub const SETHOSTNAME : usize = 161;
+pub const SETRLIMIT : usize = 164;
+pub const GETRLIMIT : usize = 163;
+pub const GETRUSAGE : usize = 165;
+pub const GETTIMEOFDAY : usize = 169;
+pub const SETTIMEOFDAY : usize = 170;
+pub const GETGROUPS : usize = 158;
+pub const SETGROUPS : usize = 159;
+
+pub const SWAPON : usize = 224;
+pub const REBOOT : usize = 142;
+pub const MMAP : usize = 222;
+pub const MUNMAP : usize = 215;
+pub const TRUNCATE : usize = 45;
+pub const FTRUNCATE : usize = 46;
+pub const FCHMOD : usize = 52;
+pub const FCHOWN : usize = 55;
+pub const GETPRIORITY : usize = 141;
+pub const SETPRIORITY : usize = 140;
+
+pub const STATFS : usize = 43;
+pub const FSTATFS : usize = 44;
+
+pub const SYSLOG : usize = 116;
+pub const SETITIMER : usize = 103;
+pub const GETITIMER : usize = 102;
+pub const FSTAT : usize = 80;
+
+pub const VHANGUP : usize = 58;
+
+pub const WAIT4 : usize = 260;
+pub const SWAPOFF : usize = 225;
+pub const SYSINFO : usize = 179;
+pub const FSYNC : usize = 82;
+pub const CLONE : usize = 220;
+pub const SETDOMAINNAME : usize = 162;
+pub const UNAME : usize = 160;
+
+pub const ADJTIMEX : usize = 171;
+pub const MPROTECT : usize = 226;
+
+pub const INIT_MODULE : usize = 105;
+pub const DELETE_MODULE : usize = 106;
+
+pub const QUOTACTL : usize = 60;
+pub const GETPGID : usize = 155;
+pub const FCHDIR : usize = 50;
+pub const PERSONALITY : usize = 92;
+
+pub const SETFSUID : usize = 151;
+pub const SETFSGID : usize = 152;
+pub const FLOCK : usize = 32;
+pub const MSYNC : usize = 227;
+pub const READV : usize = 65;
+pub const WRITEV : usize = 66;
+pub const GETSID : usize = 156;
+pub const FDATASYNC : usize = 83;
+pub const MLOCK : usize = 228;
+pub const MUNLOCK : usize = 229;
+pub const MLOCKALL : usize = 230;
+pub const MUNLOCKALL : usize = 231;
+pub const SCHED_SETPARAM : usize = 118;
+pub const SCHED_GETPARAM : usize = 121;
+pub const SCHED_SETSCHEDULER : usize = 119;
+pub const SCHED_GETSCHEDULER : usize = 120;
+pub const SCHED_YIELD : usize = 124;
+pub const SCHED_GET_PRIORITY_MAX : usize = 125;
+pub const SCHED_GET_PRIORITY_MIN : usize = 126;
+pub const SCHED_RR_GET_INTERVAL : usize = 127;
+pub const NANOSLEEP : usize = 101;
+pub const MREMAP : usize = 216;
+pub const SETRESUID : usize = 147;
+pub const GETRESUID : usize = 148;
+
+pub const NFSSERVCTL : usize = 42;
+pub const SETRESGID : usize = 149;
+pub const GETRESGID : usize = 150;
+pub const PRCTL : usize = 167;
+pub const RT_SIGRETURN : usize = 139;
+pub const RT_SIGACTION : usize = 134;
+pub const RT_SIGPROCMASK : usize = 135;
+pub const RT_SIGPENDING : usize = 136;
+pub const RT_SIGTIMEDWAIT : usize = 137;
+pub const RT_SIGQUEUEINFO : usize = 138;
+pub const RT_SIGSUSPEND : usize = 133;
+pub const PREAD64 : usize = 67;
+pub const PWRITE64 : usize = 68;
+pub const GETCWD : usize = 17;
+pub const CAPGET : usize = 90;
+pub const CAPSET : usize = 91;
+pub const SIGALTSTACK : usize = 132;
+pub const SENDFILE : usize = 71;
+
+pub const GETDENTS64 : usize = 61;
+pub const PIVOT_ROOT : usize = 41;
+pub const MINCORE : usize = 232;
+pub const MADVISE : usize = 233;
+
+pub const GETTID : usize = 178;
+pub const READAHEAD : usize = 213;
+pub const SETXATTR : usize = 5;
+pub const LSETXATTR : usize = 6;
+pub const FSETXATTR : usize = 7;
+pub const GETXATTR : usize = 8;
+pub const LGETXATTR : usize = 9;
+pub const FGETXATTR : usize = 10;
+pub const LISTXATTR : usize = 11;
+pub const LLISTXATTR : usize = 12;
+pub const FLISTXATTR : usize = 13;
+pub const REMOVEXATTR : usize = 14;
+pub const LREMOVEXATTR : usize = 15;
+pub const FREMOVEXATTR : usize = 16;
+pub const TKILL : usize = 130;
+pub const FUTEX : usize = 98;
+pub const SCHED_SETAFFINITY : usize = 122;
+pub const SCHED_GETAFFINITY : usize = 123;
+pub const IO_SETUP : usize = 0;
+pub const IO_DESTROY : usize = 1;
+pub const IO_GETEVENTS : usize = 4;
+pub const IO_SUBMIT : usize = 2;
+pub const IO_CANCEL : usize = 3;
+pub const EXIT_GROUP : usize = 94;
+pub const LOOKUP_DCOOKIE : usize = 18;
+pub const EPOLL_CTL : usize = 21;
+pub const REMAP_FILE_PAGES : usize = 234;
+
+pub const SET_TID_ADDRESS : usize = 96;
+pub const TIMER_CREATE : usize = 107;
+pub const TIMER_SETTIME : usize = 110;
+pub const TIMER_GETTIME : usize = 108;
+pub const TIMER_GETOVERRUN : usize = 109;
+pub const TIMER_DELETE : usize = 111;
+pub const CLOCK_SETTIME : usize = 112;
+pub const CLOCK_GETTIME : usize = 113;
+pub const CLOCK_GETRES : usize = 114;
+pub const CLOCK_NANOSLEEP : usize = 115;
+pub const TGKILL : usize = 131;
+pub const MQ_OPEN : usize = 180;
+pub const MQ_UNLINK : usize = 181;
+pub const MQ_TIMEDSEND : usize = 182;
+pub const MQ_TIMEDRECEIVE : usize = 183;
+pub const MQ_NOTIFY : usize = 184;
+pub const MQ_GETSETATTR : usize = 185;
+pub const WAITID : usize = 95;
+pub const SOCKET : usize = 198;
+pub const BIND : usize = 200;
+pub const CONNECT : usize = 203;
+pub const LISTEN : usize = 201;
+pub const ACCEPT : usize = 202;
+pub const GETSOCKNAME : usize = 204;
+pub const GETPEERNAME : usize = 205;
+pub const SOCKETPAIR : usize = 199;
+pub const SENDTO : usize = 206;
+pub const RECVFROM : usize = 207;
+pub const SHUTDOWN : usize = 210;
+pub const SETSOCKOPT : usize = 208;
+pub const GETSOCKOPT : usize = 209;
+pub const SENDMSG : usize = 211;
+pub const RECVMSG : usize = 212;
+pub const SEMOP : usize = 193;
+pub const SEMGET : usize = 190;
+pub const SEMCTL : usize = 191;
+pub const MSGSND : usize = 189;
+pub const MSGRCV : usize = 188;
+pub const MSGGET : usize = 186;
+pub const MSGCTL : usize = 187;
+pub const SHMAT : usize = 196;
+pub const SHMDT : usize = 197;
+pub const SHMGET : usize = 194;
+pub const SHMCTL : usize = 195;
+pub const ADD_KEY : usize = 217;
+pub const REQUEST_KEY : usize = 218;
+pub const KEYCTL : usize = 219;
+pub const SEMTIMEDOP : usize = 192;
+pub const IOPRIO_SET : usize = 30;
+pub const IOPRIO_GET : usize = 31;
+pub const INOTIFY_ADD_WATCH : usize = 27;
+pub const INOTIFY_RM_WATCH : usize = 28;
+pub const MBIND : usize = 235;
+pub const GET_MEMPOLICY : usize = 236;
+pub const SET_MEMPOLICY : usize = 237;
+pub const OPENAT : usize = 56;
+pub const MKDIRAT : usize = 34;
+pub const MKNODAT : usize = 33;
+pub const FCHOWNAT : usize = 54;
+pub const UNLINKAT : usize = 35;
+pub const RENAMEAT : usize = 38;
+pub const LINKAT : usize = 37;
+pub const SYMLINKAT : usize = 36;
+pub const READLINKAT : usize = 78;
+pub const FCHMODAT : usize = 53;
+pub const FACCESSAT : usize = 48;
+pub const PSELECT6 : usize = 72;
+pub const PPOLL : usize = 73;
+pub const UNSHARE : usize = 97;
+pub const SET_ROBUST_LIST : usize = 99;
+pub const GET_ROBUST_LIST : usize = 100;
+pub const SPLICE : usize = 76;
+pub const TEE : usize = 77;
+pub const VMSPLICE : usize = 75;
+pub const MOVE_PAGES : usize = 239;
+pub const GETCPU : usize = 168;
+pub const EPOLL_PWAIT : usize = 22;
+pub const KEXEC_LOAD : usize = 104;
+pub const UTIMENSAT : usize = 88;
+pub const TIMERFD_CREATE : usize = 85;
+pub const FALLOCATE : usize = 47;
+pub const TIMERFD_SETTIME : usize = 86;
+pub const TIMERFD_GETTIME : usize = 87;
+pub const SIGNALFD4 : usize = 74;
+pub const EVENTFD2 : usize = 19;
+pub const EPOLL_CREATE1 : usize = 20;
+pub const DUP3 : usize = 24;
+pub const PIPE2 : usize = 59;
+pub const INOTIFY_INIT1 : usize = 26;
+pub const PREADV : usize = 69;
+pub const PWRITEV : usize = 70;
+pub const RT_TGSIGQUEUEINFO : usize = 240;
+pub const PERF_EVENT_OPEN : usize = 241;
+pub const RECVMMSG : usize = 243;
+pub const ACCEPT4 : usize = 242;
+pub const FANOTIFY_INIT : usize = 262;
+pub const FANOTIFY_MARK : usize = 263;
+pub const PRLIMIT64 : usize = 261;
+pub const NAME_TO_HANDLE_AT : usize = 264;
+pub const OPEN_BY_HANDLE_AT : usize = 265;
+pub const CLOCK_ADJTIME : usize = 266;
+pub const SYNCFS : usize = 267;
+pub const SENDMMSG : usize = 269;
+pub const SETNS : usize = 268;
+pub const PROCESS_VM_READV : usize = 270;
+pub const PROCESS_VM_WRITEV : usize = 271;
+pub const KCMP : usize = 272;
+pub const FINIT_MODULE : usize = 273;


### PR DESCRIPTION
This PR adds aarch64 syscalls for linux. The calls were added by:-
* Passing the musl source code from clang to generate llvm bitcode
* Verifying the code with the calling convention documented at <https://wiki.cdot.senecacollege.ca/wiki/Syscalls>

I haven't got a QEMU based rust install here, so I have no way of verifying these.

Many of the system call numbers are not known, despite running `nr.rs.c` against a linux 4.6 source tree with `make install_headers`. I'd hope you'll take this patch as is, and then we can always add syscalls as needed. It might be worth documenting that these are missing in a README or somesuch.

A good source of syscall numbers is actually musl; it might be worth simply auto-converting that. The source code I've created doesn't match your formatting style. I couldn't quite find the right settings for that. I'd prefer it if you took my PR and then re-formatted if you want to.

If there's interest, I can attempt to create powerpc64 and mips (32-bit) platforms for linux.